### PR TITLE
Convert internal src imports to relative imports

### DIFF
--- a/src/core/controller.py
+++ b/src/core/controller.py
@@ -1,18 +1,18 @@
 import threading
 from typing import Callable, List, Dict
 
-from modules.input import InputSignal
-from core.module import DogModule
-from core.registry import ModuleRegistry, ModuleType
-from modules.audio import AudioModule
-from modules.input import InputModule
-from modules.movement import MovementModule
-from modules.ocr import OCRModule
-from modules.video import VideoModule
-from modules.lidar import LIDARModule
-from hardware.interfaces.hardware_interface import HardwareInterface
-from hardware.native.native_hardware import NativeHardware
-from hardware.virtual.virtual_hardware import VirtualHardware
+from ..modules.input import InputSignal
+from .module import DogModule
+from .registry import ModuleRegistry, ModuleType
+from ..modules.audio import AudioModule
+from ..modules.input import InputModule
+from ..modules.movement import MovementModule
+from ..modules.ocr import OCRModule
+from ..modules.video import VideoModule
+from ..modules.lidar import LIDARModule
+from ..hardware.interfaces.hardware_interface import HardwareInterface
+from ..hardware.native.native_hardware import NativeHardware
+from ..hardware.virtual.virtual_hardware import VirtualHardware
 
 
 # TTS: https://medium.com/@vndee.huynh/build-your-own-voice-assistant-and-run-it-locally-whisper-ollama-bark-c80e6f815cba

--- a/src/core/registry.py
+++ b/src/core/registry.py
@@ -2,13 +2,13 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Dict, Generic, Optional, Type, TypeVar
 
-from core.module import DogModule
-from modules.audio import AudioModule
-from modules.input import InputModule
-from modules.lidar import LIDARModule
-from modules.movement import MovementModule
-from modules.ocr import OCRModule
-from modules.video import VideoModule
+from .module import DogModule
+from ..modules.audio import AudioModule
+from ..modules.input import InputModule
+from ..modules.lidar import LIDARModule
+from ..modules.movement import MovementModule
+from ..modules.ocr import OCRModule
+from ..modules.video import VideoModule
 
 
 T = TypeVar('T', bound=DogModule)

--- a/src/hardware/native/native_hardware.py
+++ b/src/hardware/native/native_hardware.py
@@ -4,7 +4,7 @@ from typing_extensions import override
 from unitree_sdk2py.core.channel import ChannelFactoryInitialize
 from unitree_sdk2py.go2.sport.sport_client import SportClient
 
-from hardware.interfaces.hardware_interface import HardwareInterface
+from ..interfaces.hardware_interface import HardwareInterface
 
 
 class NativeHardware(HardwareInterface):

--- a/src/hardware/virtual/virtual_hardware.py
+++ b/src/hardware/virtual/virtual_hardware.py
@@ -3,7 +3,7 @@ import signal
 import subprocess
 from typing_extensions import override
 
-from hardware.interfaces.hardware_interface import HardwareInterface
+from ..interfaces.hardware_interface import HardwareInterface
 
 
 class VirtualHardware(HardwareInterface):

--- a/src/integrations/follow_path_original.py
+++ b/src/integrations/follow_path_original.py
@@ -8,12 +8,12 @@ import cv2
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 sys.path.insert(0, ROOT)
 
-from integrations.aruko_helpers import *
+from .aruko_helpers import *
 
-from core.controller import Go2Controller
-from core.registry import ModuleType
-from states.dog_state import DogStateAbstract
-from modules.video.camera_source_factory import CameraSourceFactory
+from ..core.controller import Go2Controller
+from ..core.registry import ModuleType
+from ..states.dog_state import DogStateAbstract
+from ..modules.video.camera_source_factory import CameraSourceFactory
 
 
 class MarkerMappings(Enum):

--- a/src/integrations/follow_path_simple.py
+++ b/src/integrations/follow_path_simple.py
@@ -8,10 +8,10 @@ import cv2
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 sys.path.insert(0, ROOT)
 
-from integrations.aruko_helpers import *
-from core.controller import Go2Controller
-from core.registry import ModuleType
-from modules.video.camera_source_factory import CameraSourceFactory
+from .aruko_helpers import *
+from ..core.controller import Go2Controller
+from ..core.registry import ModuleType
+from ..modules.video.camera_source_factory import CameraSourceFactory
 
 
 # ============================================================================

--- a/src/integrations/tests.py
+++ b/src/integrations/tests.py
@@ -4,9 +4,9 @@ import sys
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 sys.path.insert(0, ROOT)
 
-from core.controller import Go2Controller
-from core.registry import ModuleType
-from modules.video.camera_source_factory import CameraSourceFactory
+from ..core.controller import Go2Controller
+from ..core.registry import ModuleType
+from ..modules.video.camera_source_factory import CameraSourceFactory
 
 import time
 import cv2

--- a/src/modules/audio/audio_module.py
+++ b/src/modules/audio/audio_module.py
@@ -1,7 +1,7 @@
 import threading
 import pyttsx3
 from typing_extensions import override
-from core.module import DogModule
+from ...core.module import DogModule
 
 
 class AudioModule(DogModule):

--- a/src/modules/input/input_module.py
+++ b/src/modules/input/input_module.py
@@ -5,8 +5,8 @@ from .callback_manager import InputSignalCallbackManager, UnitreeRemoteControlle
 from .controller_state import ControllerState
 from .input_signal import InputSignal
 
-from core.module import DogModule
-from communication.dds.dds import DDS_TOPICS
+from ...core.module import DogModule
+from ...communication.dds.dds import DDS_TOPICS
 
 
 class InputModule(DogModule):

--- a/src/modules/lidar/lidar_module.py
+++ b/src/modules/lidar/lidar_module.py
@@ -5,7 +5,7 @@ import numpy as np
 from typing import Callable, Any
 from typing_extensions import override
 
-from core.module import DogModule
+from ...core.module import DogModule
 from .callback_dispatcher import CallbackDispatcher
 from .zmq_receiver import ZMQReceiver
 

--- a/src/modules/movement/movement_module.py
+++ b/src/modules/movement/movement_module.py
@@ -1,7 +1,7 @@
 from typing_extensions import override
 
-from core.module import DogModule
-from hardware.interfaces.hardware_interface import HardwareInterface
+from ...core.module import DogModule
+from ...hardware.interfaces.hardware_interface import HardwareInterface
 
 
 class MovementModule(DogModule):

--- a/src/modules/ocr/ocr_module.py
+++ b/src/modules/ocr/ocr_module.py
@@ -3,7 +3,7 @@ import numpy as np
 import pytesseract
 from typing_extensions import override
 
-from core.module import DogModule
+from ...core.module import DogModule
 
 
 class OCRModule(DogModule):

--- a/src/modules/video/video_module.py
+++ b/src/modules/video/video_module.py
@@ -3,7 +3,7 @@ from typing_extensions import override
 
 import numpy as np
 
-from core.module import DogModule
+from ...core.module import DogModule
 from .streamer import WebRTCStreamer
 from .camera_source import CameraSource
 

--- a/src/states/dog_state.py
+++ b/src/states/dog_state.py
@@ -18,7 +18,7 @@ This framework provides:
 from abc import ABC, abstractmethod
 from typing import Any, final
 
-from core.controller import Go2Controller
+from ..core.controller import Go2Controller
 from .validation import CancellableMeta
 
 


### PR DESCRIPTION
### Motivation

- Ensure intra-package imports within the `src/` package use explicit relative imports so modules resolve correctly when the package is used as a package rather than relying on top-level absolute paths or temporary `sys.path` manipulation.
- Reduce fragility around import resolution and make the codebase more standard-Python-package friendly for packaging and testing.

### Description

- Converted absolute internal imports like `from core.module import DogModule` and `from modules.video import VideoModule` to relative forms such as `from .module import DogModule` and `from ..modules.video import VideoModule` across the package.
- Updated import statements in the following files: `src/core/controller.py`, `src/core/registry.py`, `src/states/dog_state.py`, `src/modules/audio/audio_module.py`, `src/modules/input/input_module.py`, `src/modules/lidar/lidar_module.py`, `src/modules/movement/movement_module.py`, `src/modules/ocr/ocr_module.py`, `src/modules/video/video_module.py`, `src/hardware/native/native_hardware.py`, `src/hardware/virtual/virtual_hardware.py`, `src/integrations/follow_path_original.py`, `src/integrations/follow_path_simple.py`, and `src/integrations/tests.py`.
- Left third-party and external imports unchanged and removed reliance on inserting the repository root into `sys.path` for internal references where appropriate.

### Testing

- Ran `python -m compileall src` and the compilation completed successfully, verifying import syntax and module compilation.
- No additional automated test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6f2865a248332be84bb4d58ba1a9f)